### PR TITLE
Hot fix for finding exactMatch of degC

### DIFF
--- a/qudt-core/src/main/java/com/occamsystems/qudt/UnitIndex.java
+++ b/qudt-core/src/main/java/com/occamsystems/qudt/UnitIndex.java
@@ -256,17 +256,25 @@ public class UnitIndex {
       return Optional.of(lu);
     }
 
-    if (this.preferredUnits.containsKey(base.dv())) {
-      Optional<LiteralUnit> preferredMatch =
-          exactMatch(base, this.preferredUnits.get(base.dv()).stream());
-      if (preferredMatch.isPresent()) {
-        return preferredMatch;
-      }
-    }
+    // TODO: Not sure why this picks up degC to K. But I believe this should be done after finding candidates
+//    if (this.preferredUnits.containsKey(base.dv())) {
+//      Optional<LiteralUnit> preferredMatch =
+//          exactMatch(base, this.preferredUnits.get(base.dv()).stream());
+//      if (preferredMatch.isPresent()) {
+//        return preferredMatch;
+//      }
+//    }
 
     LiteralUnit[] matches = Units.byDV.getOrDefault(base.dv().indexCode(), new LiteralUnit[] {});
     Collection<LiteralUnit> runtimeMatches =
         this.runtimeUnits.getOrDefault(base.dv().indexCode(), Collections.emptyList());
+
+    // Check if there are any direct matches
+    for (LiteralUnit unit : matches) {
+      if (unit.symbol().equals(base.symbol())) {
+        return Optional.of(unit);
+      }
+    }
 
     return exactMatch(base, Stream.concat(Arrays.stream(matches), runtimeMatches.stream()));
   }
@@ -275,6 +283,7 @@ public class UnitIndex {
     double cm = base.conversionMultiplier();
     double co = base.conversionOffset();
 
+    // TODO: degC conversionOffset is 0 as base, but is 274.15 for real unit
     return candidates
         .filter(u -> cm == u.conversionMultiplier() && co == u.conversionOffset())
         .sorted(

--- a/qudt-core/src/test/java/com/occamsystems/qudt/UnitIndexTest.java
+++ b/qudt-core/src/test/java/com/occamsystems/qudt/UnitIndexTest.java
@@ -184,4 +184,13 @@ class UnitIndexTest {
     System.out.println("Found exact literals for 8192 random aggregate pairs in " + time + "ms");
     System.out.println((int) (((double) time) / 8.192) + "us per literal");
   }
+
+
+  @Test
+  void degCParse() {
+    UnitIndex index = new UnitIndex();
+    QuantityValue quantityValue = index.parseQuantity("10 °C");
+    Assertions.assertEquals(10, quantityValue.value());
+    Assertions.assertEquals(H1Units.DEG_C.u, quantityValue.unit());
+  }
 }


### PR DESCRIPTION
When trying to parse something like 10 °C, the parsed quantity value becomes 10 K. The preferred units force the temperature units into K. This removes that perferred unit logic, and checks if any units directly matched the targetted unit